### PR TITLE
Added new Guideline

### DIFF
--- a/index.md
+++ b/index.md
@@ -55,6 +55,7 @@ Id | Description
 ------------ | -------------
 G100.1 | Only two subscription owners allowed.
 G100.2 | PIM for Admin Accounts required.
+G100.3 | Tag "ServiceOwner" required on all subscriptions.
 
 
 


### PR DESCRIPTION
This is necessary to know the service owner after the subscription is created. We can use this tag to make a report per service. We know who is responsible for the subscription.